### PR TITLE
Fix statement splitter to treat PostgreSQL dollar-quoted strings as opaque

### DIFF
--- a/gantry/sql/dialect.py
+++ b/gantry/sql/dialect.py
@@ -17,6 +17,7 @@ _OBJECT = re.compile(
     re.IGNORECASE,
 )
 _FUNCTION = re.compile(r"\b([A-Za-z_][A-Za-z0-9_$]*)\s*\(")
+_DOLLAR_QUOTE = re.compile(r"\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$")
 _DDL = {"CREATE", "ALTER", "DROP", "TRUNCATE", "GRANT", "REVOKE", "COMMENT"}
 _OPERATIONS = {
     "SELECT": SQLOperation.SELECT,
@@ -111,10 +112,15 @@ def _split_statements(sql: str) -> tuple[str, ...]:
     parts: list[str] = []
     start = 0
     quote: str | None = None
+    dollar_quote: str | None = None
     index = 0
     while index < len(sql):
         char = sql[index]
-        if quote is not None:
+        if dollar_quote is not None:
+            if sql.startswith(dollar_quote, index):
+                index += len(dollar_quote) - 1
+                dollar_quote = None
+        elif quote is not None:
             if char == quote:
                 if index + 1 < len(sql) and sql[index + 1] == quote:
                     index += 1
@@ -122,6 +128,11 @@ def _split_statements(sql: str) -> tuple[str, ...]:
                     quote = None
         elif char in {"'", '"', "`"}:
             quote = char
+        elif char == "$":
+            match = _DOLLAR_QUOTE.match(sql, index)
+            if match is not None:
+                dollar_quote = match.group(0)
+                index += len(dollar_quote) - 1
         elif char == "-" and index + 1 < len(sql) and sql[index + 1] == "-":
             newline = sql.find("\n", index + 2)
             index = len(sql) if newline == -1 else newline

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -243,6 +243,23 @@ def test_conservative_dialect_handles_comments_quotes_ctes_and_multiple_statemen
     assert multiple.statement_count == 2
 
 
+def test_conservative_dialect_treats_dollar_quoted_bodies_as_opaque() -> None:
+    dialect = ConservativeDialect()
+
+    untagged = dialect.classify("SELECT regexp_replace(note, $$a;b$$, '') FROM analytics.customers")
+    tagged = dialect.classify("SELECT $tag$one; two$tag$ FROM analytics.customers")
+    control = dialect.classify("SELECT $$one$$; SELECT 2")
+
+    assert untagged.operation is SQLOperation.SELECT
+    assert untagged.statement_count == 1
+    assert untagged.read_only
+    assert tagged.operation is SQLOperation.SELECT
+    assert tagged.statement_count == 1
+    assert tagged.read_only
+    assert control.operation is SQLOperation.MULTI_STATEMENT
+    assert control.statement_count == 2
+
+
 def test_policy_normalizes_allow_lists_and_checks_explain_limits() -> None:
     policy = SQLPolicy(
         allowed_schemas=["Analytics"],


### PR DESCRIPTION
## Summary

Fixes #7.

`ConservativeDialect._split_statements` tracks quotes and comments but not PostgreSQL dollar-quoted strings, so a semicolon inside a `$$...$$` or `$tag$...$tag$` body splits one statement into several. A single `SELECT` like the issue's repro is then classified as `MULTI_STATEMENT` and rejected by read-only enforcement.

## Changes

- `gantry/sql/dialect.py`: add a dollar-quote state to the splitter. On `$`, match the documented tag grammar (`$[A-Za-z_][A-Za-z0-9_]*$` or `$$`), then scan to the matching closing tag with the body treated as opaque. Tags close only on exact match; an unterminated tag scans to end, mirroring unterminated block comments, so the splitter keeps failing closed.
- `tests/test_sql.py`: add `test_conservative_dialect_treats_dollar_quoted_bodies_as_opaque` covering both repro cases from the issue plus a control showing genuine multi-statement input still splits.

## Verification

- Both repro cases fail before this change (classified as `MULTI_STATEMENT`) and pass after.
- `make check` passes: ruff, mypy, full test suite (133 passed, 12 skipped), and the package build.