### PR TITLE
ci: add dependabot and CI concurrency group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule: { interval: weekly }
+  - package-ecosystem: uv
+    directory: /
+    schedule: { interval: weekly }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for weekly `github-actions` and `uv` (Python dev deps) update PRs
- Add a `concurrency` group to `ci.yml` so superseded runs on the same ref are cancelled instead of piling up on repeated pushes

Fixes #3

## Test plan
- [x] Validated YAML syntax loads cleanly
- [x] `ci.yml` diff limited to the added `concurrency` block; no other behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)