### PR TITLE
ci: run live PostgreSQL tests in CI, add a scheduled Flink live job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: ci
 on:
   push:
   pull_request:
+  workflow_dispatch:
+  schedule:
+    # Every Monday at 06:00 UTC. The Flink live tests bring up a heavier
+    # compose stack than a service container, so they run on their own
+    # schedule rather than on every push.
+    - cron: "0 6 * * 1"
 
 permissions:
   contents: read
@@ -32,14 +38,69 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12", "3.13"]
+    # A real PostgreSQL for tests/test_postgres_live.py — the one place the
+    # adapter runs against an actual `information_schema`, not a stub. Cheap
+    # enough as a service container to run on every push, unlike Flink.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: gantry
+          POSTGRES_PASSWORD: gantry
+          POSTGRES_DB: gantry
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
-      - run: uv sync
+      - run: uv sync --extra postgres
+      - run: psql "$GANTRY_TEST_POSTGRES_URL" -f examples/seed.sql
+        env:
+          GANTRY_TEST_POSTGRES_URL: postgresql://gantry:gantry@localhost:5432/gantry
       # mypy no longer pins python_version, so it type-checks under the
       # semantics of whichever interpreter is running rather than always 3.12.
       - run: uv run mypy gantry tests
-      - run: uv run pytest --cov=gantry --cov-report=term-missing
+      # test_flink_live.py has no Flink here — it belongs to the flink-live
+      # job below, on its own schedule. GANTRY_REQUIRE_LIVE turns a
+      # postgres-unreachable skip into a failure, so a broken fixture (or a
+      # service container that silently failed to start) cannot pass as a
+      # green skip.
+      - run: uv run pytest --cov=gantry --cov-report=term-missing --ignore=tests/test_flink_live.py
+        env:
+          GANTRY_REQUIRE_LIVE: "1"
+          GANTRY_TEST_POSTGRES_URL: postgresql://gantry:gantry@localhost:5432/gantry
+
+  # Heavier than a service container — a full JobManager/TaskManager/SQL
+  # Gateway stack, built from examples/flink/. On demand or weekly rather
+  # than on every push, per the plan in issue #10.
+  flink-live:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - run: uv sync
+      - run: docker compose -f examples/stack/docker-compose.yml up -d --wait
+      - run: psql "$GANTRY_TEST_POSTGRES_URL" -f examples/seed.sql
+        env:
+          GANTRY_TEST_POSTGRES_URL: postgresql://gantry:gantry@localhost:5432/gantry
+      # GANTRY_REQUIRE_LIVE turns a gateway/catalog-unreachable skip into a
+      # failure — the exact failure mode test_flink_live.py's own docstring
+      # already records having happened once (a NameError read as "no
+      # catalogs" and skipped the whole file).
+      - run: uv run pytest tests/test_flink_live.py -q
+        env:
+          GANTRY_REQUIRE_LIVE: "1"
+      - if: always()
+        run: docker compose -f examples/stack/docker-compose.yml down -v

--- a/tests/_live.py
+++ b/tests/_live.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helper for the live-provider test files.
+
+Skipping is right for a developer running the suite without the
+infrastructure a live test needs. In CI, that skip is indistinguishable from
+one caused by a broken fixture — both stay green. Setting
+`GANTRY_REQUIRE_LIVE=1` removes the ambiguity for jobs that bring the
+infrastructure up themselves: a skip becomes a failure instead.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def require_live_or_skip(reason: str) -> None:
+    """Skip, unless the caller promised this infrastructure would be up."""
+    if os.environ.get("GANTRY_REQUIRE_LIVE") == "1":
+        pytest.fail(reason)
+    pytest.skip(reason)

--- a/tests/test_flink_live.py
+++ b/tests/test_flink_live.py
@@ -11,9 +11,11 @@ test passed.
 Skipped unless a gateway is reachable, so a clone without one still passes.
 Bring one up with:
 
-    docker compose -f examples/flink/docker-compose.yml up -d
+    docker compose -f examples/stack/docker-compose.yml up -d --wait
 
-Set GANTRY_TEST_FLINK_GATEWAY / GANTRY_TEST_FLINK_JOBMANAGER to point elsewhere.
+Set GANTRY_TEST_FLINK_GATEWAY / GANTRY_TEST_FLINK_JOBMANAGER to point
+elsewhere. Set GANTRY_REQUIRE_LIVE=1 in a job that is supposed to have a
+gateway up, so an unreachable one fails loudly instead of skipping.
 """
 
 from __future__ import annotations
@@ -28,6 +30,8 @@ import gantry
 import pytest
 from gantry.batch import BatchConnection
 from gantry.flink.operation import FlinkBatchJob
+
+from _live import require_live_or_skip
 
 GATEWAY = os.environ.get("GANTRY_TEST_FLINK_GATEWAY", "http://localhost:8083")
 JOBMANAGER = os.environ.get("GANTRY_TEST_FLINK_JOBMANAGER", "http://localhost:8081")
@@ -100,9 +104,9 @@ def _catalogs() -> set[str]:
 @pytest.fixture
 def flink() -> BatchConnection:
     if not _reachable(f"{GATEWAY}/info") or not _reachable(f"{JOBMANAGER}/overview"):
-        pytest.skip(f"no Flink at {GATEWAY} / {JOBMANAGER}")
+        require_live_or_skip(f"no Flink at {GATEWAY} / {JOBMANAGER}")
     if CATALOG not in _catalogs():
-        pytest.skip(f"catalog {CATALOG!r} is not registered on the gateway")
+        require_live_or_skip(f"catalog {CATALOG!r} is not registered on the gateway")
     return gantry.batch.connect(
         "flink",
         endpoint=GATEWAY,

--- a/tests/test_postgres_live.py
+++ b/tests/test_postgres_live.py
@@ -9,7 +9,8 @@ column does not exist, and nothing noticed because nothing ran it.
 Skipped unless a database is reachable, so a clone without one still passes.
 Point it somewhere with `GANTRY_TEST_POSTGRES_URL` — including at Neon or
 Supabase, where the same tests are a useful check that the provider preset and
-TLS settings are right.
+TLS settings are right. Set `GANTRY_REQUIRE_LIVE=1` in a job that is supposed
+to have a database up, so an unreachable one fails loudly instead of skipping.
 """
 
 from __future__ import annotations
@@ -18,6 +19,8 @@ import os
 
 import gantry
 import pytest
+
+from _live import require_live_or_skip
 
 URL = os.environ.get("GANTRY_TEST_POSTGRES_URL", "postgresql://gantry:gantry@localhost:5432/gantry")
 PROVIDER = os.environ.get("GANTRY_TEST_POSTGRES_PROVIDER", "postgres")
@@ -49,7 +52,7 @@ async def _reachable() -> bool:
 async def db() -> gantry.sql.SQLConnection:
     connection = _connect()
     if not await _reachable():
-        pytest.skip(f"no PostgreSQL at {URL.rsplit('@', 1)[-1]}")
+        require_live_or_skip(f"no PostgreSQL at {URL.rsplit('@', 1)[-1]}")
     return connection
 
 


### PR DESCRIPTION
## Summary

`tests/test_postgres_live.py` and `tests/test_flink_live.py` are the only tests that exercise real provider behavior, but both always skip in CI since neither PostgreSQL nor Flink runs there — so on every push these files stay green whether or not the claims they check (read-only enforcement, row limits, timeouts, cancellation, durable handles) actually hold.

- Add a `postgres:16-alpine` service container to the `test` job, seed it from `examples/seed.sql`, and run `tests/test_postgres_live.py` for real on every push/PR.
- Add a separate `flink-live` job, gated on `workflow_dispatch` and a weekly schedule (Monday 06:00 UTC), that brings up `examples/stack/docker-compose.yml` and runs `tests/test_flink_live.py`. The compose stack (JobManager/TaskManager/SQL Gateway) is heavier than a service container, so it doesn't run on every push.
- Add `tests/_live.py` with a shared `require_live_or_skip()` helper. Both live test fixtures now call it instead of `pytest.skip()` directly: it skips as before by default, but fails when `GANTRY_REQUIRE_LIVE=1` is set — so a job that promised the infrastructure would be up can't pass with a silent skip caused by a typo'd fixture or a container that failed to start. Legitimate data-dependent skips (e.g. "no user tables yet", "job finished before it could be observed running") are untouched.

Fixes #10

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy gantry tests`
- [x] `uv run pytest --cov=gantry --cov-report=term-missing` — 138 passed, 12 skipped, 77.89% coverage
- [x] `uv run python -m build`
- [x] Verified locally against a real `postgres:16-alpine` container seeded with `examples/seed.sql`: without `GANTRY_REQUIRE_LIVE`, unreachable DB skips as before; with it set, unreachable DB fails the fixture (`pytest.fail`); against the real container, all 5 live PostgreSQL tests pass.
- [x] Validated the workflow YAML parses and both new/changed jobs (`test`, `flink-live`) are present.
- [ ] `flink-live` job itself only exercises on GitHub Actions via `workflow_dispatch`/the weekly schedule — not runnable to completion in this sandbox (would need to build/boot the full Flink image stack), so please trigger it manually once merged to confirm end-to-end.